### PR TITLE
Downloader app support

### DIFF
--- a/app/Module.scala
+++ b/app/Module.scala
@@ -1,7 +1,7 @@
 import actors.{Audit, ObjectCache}
 import com.google.inject.AbstractModule
 import helpers.UserInfoCache
-import models.{AuditRecordDAO, AuditRecordDAOElastic, AuditRecordDAOMongo, AuditRecordDAONull}
+import models.{AuditRecordDAO, AuditRecordDAOElastic, AuditRecordDAOMongo, AuditRecordDAONull, ServerTokenDAO, ServerTokenDAORedis}
 import org.slf4j.LoggerFactory
 import play.api.libs.concurrent.AkkaGuiceSupport
 
@@ -18,6 +18,8 @@ class Module extends AbstractModule with AkkaGuiceSupport {
       case Some("none") =>
         bind(classOf[AuditRecordDAO]).to(classOf[AuditRecordDAONull])
     }
+
+    bind(classOf[ServerTokenDAO]).to(classOf[ServerTokenDAORedis])
 
     bindActor[ObjectCache]("object-cache")
     bindActor[Audit]("audit-actor")

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future
 import play.api.cache.SyncCacheApi
 import auth.Security
 import play.api.libs.circe.Circe
-import responses.FrontendConfigResponse
+import responses.{FrontendConfigResponse, GenericErrorResponse}
 import io.circe.syntax._
 import io.circe.generic.auto._
 
@@ -150,12 +150,12 @@ class Application @Inject() (cc:ControllerComponents,
         case ObjectNotFound(_) =>
           val auditFile = AuditFile("",locator.filePath)
           auditActor ! actors.Audit.LogEvent(AuditEvent.NOTFOUND, uid, Some(auditFile), Seq())
-          Left(NotFound(s"could not find object $targetUriString")) //FIXME: replace with proper json response
+          Left(NotFound(GenericErrorResponse("not_found", s"no object at $targetUriString").asJson))
         case ObjectLookupFailed(_, err) =>
           val auditFile = AuditFile("",locator.filePath)
           auditActor ! actors.Audit.LogEvent(AuditEvent.OMERROR, uid, Some(auditFile), Seq(),notes=Some(err.toString))
           logger.error(s"Could not look up object for $targetUriString: ", err)
-          Left(InternalServerError(s"lookup failed for $targetUriString"))
+          Left(InternalServerError(GenericErrorResponse("server_error", s"lookup failed for $targetUriString").asJson))
         case ObjectFound(_, objectEntry) =>
           Right(objectEntry)
       })

--- a/app/controllers/BulkDownloadController.scala
+++ b/app/controllers/BulkDownloadController.scala
@@ -1,30 +1,31 @@
 package controllers
 
-import java.time.ZonedDateTime
+import java.time.{Instant, ZonedDateTime}
 
 import akka.actor.ActorSystem
-import akka.stream.{ClosedShape, Materializer}
-import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink}
+import akka.stream.{ClosedShape, Materializer, SourceShape}
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
 import auth.Security
-import com.om.mxs.client.japi.{SearchTerm, UserInfo}
-import helpers.UserInfoCache
+import com.om.mxs.client.japi.{MatrixStore, SearchTerm, UserInfo, Vault}
+import helpers.{MetadataHelper, UserInfoCache}
 import javax.inject.Inject
-import models.{ArchiveEntryDownloadSynopsis, LightboxBulkEntry, ServerTokenDAO, ServerTokenEntry}
+import models.{ArchiveEntryDownloadSynopsis, LightboxBulkEntry, ObjectMatrixEntry, ServerTokenDAO, ServerTokenEntry}
 import play.api.Configuration
 import play.api.libs.circe.Circe
-import play.api.mvc.{AbstractController, ControllerComponents, Result}
+import play.api.mvc.{AbstractController, AnyContent, ControllerComponents, Request, ResponseHeader, Result}
 import responses.{BulkDownloadInitiateResponse, GenericErrorResponse, GenericObjectResponse}
 import io.circe.syntax._
 import io.circe.generic.auto._
 import play.api.cache.SyncCacheApi
-import streamcomponents.MakeDownloadSynopsis
+import play.api.http.HttpEntity
+import streamcomponents.{MakeDownloadSynopsis, MatrixStoreFileSourceWithRanges, OMFastSearchSource}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class BulkDownloadController @Inject() (cc:ControllerComponents, config:Configuration, serverTokenDAO: ServerTokenDAO, userInfoCache: UserInfoCache)
                                        (implicit mat:Materializer, system:ActorSystem, override implicit val cache:SyncCacheApi)
-  extends AbstractController(cc) with Circe with Security {
+  extends AbstractController(cc) with Circe with Security with ObjectMatrixEntryMixin{
 
   /**
     * looks up the given vault ID in the UserInfoCache and calls the provided block with the resolved UserInfo object.
@@ -44,6 +45,15 @@ class BulkDownloadController @Inject() (cc:ControllerComponents, config:Configur
     case None=>Future(NotFound(GenericErrorResponse("not_found","").asJson))
   }
 
+  /**
+    * called from a logged-in browser session to initiate the download session.
+    * Generates a one-time token tied to the user, project and vault, saves it and returns it to the frontend.
+    * No search or validation is done on the vault or project IDs at this point.
+    * It's assumed that the storage backend takes care of expiry
+    * @param vaultId Vault ID that is being targeted
+    * @param projectId Project ID that is being targeted
+    * @return a Play response
+    */
   def initiate(vaultId:String,projectId:String) = IsAuthenticatedAsync { uid=> request=>
     val expiry = config.getOptional[Int]("serverToken.shortLivedDuration").getOrElse(10)
     val newToken = ServerTokenEntry.create(Some(projectId + "|" + vaultId), expiry, Some(uid))
@@ -56,6 +66,13 @@ class BulkDownloadController @Inject() (cc:ControllerComponents, config:Configur
       })
   }
 
+  /**
+    * performs a streaming search against the ObjectMatrix vault and convert the returned results to
+    * ArchiveEntryDownloadSynopsis objects for sending to Download Manager
+    * @param userInfo UserInfo instance indicating the appliance and vault to target
+    * @param projectId project ID to search for
+    * @return an ArchiveEntryDownloadSynopsis object for each file of the project, returned in a Future
+    */
   def getContent(userInfo:UserInfo, projectId:String) = {
     val searchTerms = Array(SearchTerm.createSimpleTerm("GNM_PROJECT_ID", projectId))
     val usefulFields = Array("MXFS_PATH","MXFS_FILENAME","DPSP_SIZE")
@@ -72,35 +89,134 @@ class BulkDownloadController @Inject() (cc:ControllerComponents, config:Configur
     RunnableGraph.fromGraph(graph).run()
   }
 
+  /**
+    * create and save a long-term token to allow the download of items
+    * @param uid user ID creating the token
+    * @param combinedId combined vault and project ID string
+    * @return the saved ServerTokenEntry in a Future
+    */
   def createRetrievalToken(uid:String, combinedId:String) = {
     val expiry = config.getOptional[Int]("serverToken.longLivedDuration").getOrElse(3600)
     val newToken = ServerTokenEntry.create(Some(combinedId), expiry, Some(uid))
     serverTokenDAO.put(newToken, expiry).map(_=>newToken)
   }
 
+  /**
+    * handle the return of a short-lived token. Validate it and if it passes delete it, then send back a long-lived
+    * token and a list of items to download.
+    * @param tokenId the ID of a short-lived token
+    * @return
+    */
   def getBulkDownload(tokenId:String) = Action.async {
     serverTokenDAO.get(tokenId).flatMap({
       case None=>
         Future(NotFound(GenericErrorResponse("not_found","No such bulk download").asJson))
       case Some(token)=>
+        serverTokenDAO.remove(tokenId).flatMap(_=> {
         token.associatedId match {
           case None=>
             logger.error(s"Token $tokenId is invalid, it does not contain a project ID")
             Future(NotFound(GenericErrorResponse("not_found","Invalid token").asJson))
           case Some(combinedId)=>
-            serverTokenDAO.remove(tokenId).flatMap(_=> {
-              val ids = combinedId.split("|")
-              val projectId = ids.head
-              val vaultId = ids(1)
+            val ids = combinedId.split("|")
+            val projectId = ids.head
+            val vaultId = ids(1)
 
-              withVaultAsync(vaultId) { userInfo =>
+            withVaultAsync(vaultId) { userInfo =>
+              createRetrievalToken(token.createdForUser.getOrElse(""), combinedId).flatMap(retrievalToken=> {
                 getContent(userInfo, projectId).map(synopses => {
-                  val meta = LightboxBulkEntry(projectId, "", token.createdForUser.getOrElse(""), ZonedDateTime.now(), 0, synopses.length, 0)
-                  BulkDownloadInitiateResponse("ok", meta, retrievalToken, synopses)
+                  val meta = LightboxBulkEntry(projectId, s"Vaultdoor download for project $projectId", token.createdForUser.getOrElse(""), ZonedDateTime.now(), 0, synopses.length, 0)
+                  Ok(BulkDownloadInitiateResponse("ok", meta, retrievalToken.value, synopses).asJson)
                 })
-              }
-            })
-        }
+              })
+            }
+          }
+        }).recover({
+          case err:Throwable=>
+            logger.error(s"Could not get bulk download for token $tokenId: ", err)
+            InternalServerError(GenericErrorResponse("error","Server failure, please check the logs").asJson)
+        })
     })
+  }
+
+  /**
+    * validates that there is a token in the headers of the given request and that it is valid.
+    * if so, pass it on to the provided Block and return the result. Otherwise return a Play response indicating the error
+    * @param request request object
+    * @param block function to process the request if the token is valid.
+    *              Takes three parameters, being the entire ServerTokenEntry, the project ID and the vault ID as encoded in the ServerTokenEntry
+    * @return the result of the Block or a JSON formatted error response
+    */
+  def validateTokenAsync(request:Request[AnyContent])(block: (ServerTokenEntry,String,String)=>Future[Result]):Future[Result] = {
+    request.headers.get("X-Download-Token") match {
+      case None=>
+        logger.error(s"Attempt to download with no X-Download-Token header")
+        Future(BadRequest(GenericErrorResponse("bad_request","No download token in headers")))
+      case Some(tokenId)=>
+        serverTokenDAO.get(tokenId).flatMap({
+          case Some(serverToken)=>
+            logger.debug(s"Got server token $serverToken for $tokenId")
+            val updatedServerToken = serverToken.copy(uses=serverToken.uses+1)
+            val expirySeconds = Instant.now().getEpochSecond - serverToken.expiry.get.toInstant.getEpochSecond
+            if(expirySeconds<1){
+              logger.error(s"Server token $serverToken is expired")
+              Future(BadRequest(GenericErrorResponse("token_error","Expired token")))
+            } else {
+              serverTokenDAO.put(updatedServerToken, expirySeconds.toInt).flatMap(_ => {
+                val idSplit = serverToken.associatedId.get.split("|")
+                block(serverToken, idSplit.head, idSplit(1))
+              })
+            }
+          case None=>
+            Future(NotFound(GenericErrorResponse("not_found","item was not found")))
+        })
+    }
+  }
+
+  def getStreamingSourceFor(userInfo:UserInfo, omEntry:ObjectMatrixEntry) = {
+    Source.fromGraph(GraphDSL.create() { implicit builder =>
+      val src = builder.add(new MatrixStoreFileSourceWithRanges(userInfo,omEntry.oid,omEntry.fileAttribues.get.size,Seq()))
+      SourceShape(src.out)
+    })
+  }
+
+  def getMaybeResponseSize(entry:ObjectMatrixEntry, overriden:Option[Long]):Option[Long] = {
+    overriden match {
+      case value @Some(_)=>value
+      case None=>entry.fileAttribues.map(_.size)
+    }
+  }
+
+  def getMaybeMimetype(entry:ObjectMatrixEntry):Option[String] = entry.attributes.flatMap(_.stringValues.get("MXFS_MIMETYPE"))
+
+  def bulkDownloadItem(itemId:String) = Action.async { request=>
+    validateTokenAsync(request) { (serverToken, projectId, vaultId)=>
+      logger.info(s"In bulkDownloadItem for $itemId")
+
+      userInfoCache.infoForVaultId(vaultId) match {
+        case None=>
+          logger.error(s"bulkDownloadItem - vaultId is not valid, had no userInfoCache entry")
+          Future(NotFound(GenericErrorResponse("not_found","item or vault not found").asJson))
+        case Some(userInfo)=>
+          implicit val vault = MatrixStore.openVault(userInfo)
+          ObjectMatrixEntry(itemId).getMetadata.map(entry=>{
+            entry.attributes.flatMap(_.stringValues.get("GNM_PROJECT_ID")) match {
+              case None=>
+                logger.error(s"Item $itemId found in vault $vaultId but it is not a member of any project!")
+                NotFound(GenericErrorResponse("not_found","item or vault not found").asJson)
+              case Some(itemsProjectId)=>
+                if(projectId!=itemsProjectId) {
+                  logger.error(s"Item $itemId found in vault $vaultId but it is a member of project $itemsProjectId not $projectId")
+                  NotFound(GenericErrorResponse("not_found","item or vault not found").asJson)
+                } else {
+                  Result(
+                    ResponseHeader(200,headersForEntry(entry, Seq(), getMaybeResponseSize(entry, None))),
+                    HttpEntity.Streamed(getStreamingSourceFor(userInfo, entry), getMaybeResponseSize(entry, None), getMaybeMimetype(entry))
+                  )
+                }
+            }
+          })
+      }
+    }
   }
 }

--- a/app/controllers/BulkDownloadController.scala
+++ b/app/controllers/BulkDownloadController.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
 import auth.Security
 import com.om.mxs.client.japi.{MatrixStore, SearchTerm, UserInfo, Vault}
 import helpers.{MetadataHelper, UserInfoCache}
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.{ArchiveEntryDownloadSynopsis, LightboxBulkEntry, ObjectMatrixEntry, ServerTokenDAO, ServerTokenEntry}
 import play.api.Configuration
 import play.api.libs.circe.Circe
@@ -24,6 +24,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
+@Singleton
 class BulkDownloadController @Inject() (cc:ControllerComponents, config:Configuration, serverTokenDAO: ServerTokenDAO, userInfoCache: UserInfoCache)
                                        (implicit mat:Materializer, system:ActorSystem, override implicit val cache:SyncCacheApi)
   extends AbstractController(cc) with Circe with Security with ObjectMatrixEntryMixin{

--- a/app/controllers/BulkDownloadController.scala
+++ b/app/controllers/BulkDownloadController.scala
@@ -1,0 +1,106 @@
+package controllers
+
+import java.time.ZonedDateTime
+
+import akka.actor.ActorSystem
+import akka.stream.{ClosedShape, Materializer}
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink}
+import auth.Security
+import com.om.mxs.client.japi.{SearchTerm, UserInfo}
+import helpers.UserInfoCache
+import javax.inject.Inject
+import models.{ArchiveEntryDownloadSynopsis, LightboxBulkEntry, ServerTokenDAO, ServerTokenEntry}
+import play.api.Configuration
+import play.api.libs.circe.Circe
+import play.api.mvc.{AbstractController, ControllerComponents, Result}
+import responses.{BulkDownloadInitiateResponse, GenericErrorResponse, GenericObjectResponse}
+import io.circe.syntax._
+import io.circe.generic.auto._
+import play.api.cache.SyncCacheApi
+import streamcomponents.MakeDownloadSynopsis
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class BulkDownloadController @Inject() (cc:ControllerComponents, config:Configuration, serverTokenDAO: ServerTokenDAO, userInfoCache: UserInfoCache)
+                                       (implicit mat:Materializer, system:ActorSystem, override implicit val cache:SyncCacheApi)
+  extends AbstractController(cc) with Circe with Security {
+
+  /**
+    * looks up the given vault ID in the UserInfoCache and calls the provided block with the resolved UserInfo object.
+    * The block is expected to return a Play Result object and this is passed back as the ultimate result
+    * If the vault ID cannot be found then a NotFound response is returned and the block is not called
+    * @param vaultId vault ID to query
+    * @param block a block that takes a single UserInfo argument and returns a Result
+    * @return a Play Result, either the return value of the block of a NotFound
+    */
+  def withVault(vaultId:String)(block:UserInfo=>Result) = userInfoCache.infoForVaultId(vaultId) match {
+    case Some(userInfo)=>block(userInfo)
+    case None=>NotFound(GenericErrorResponse("not_found","").asJson)
+  }
+
+  def withVaultAsync(vaultId:String)(block:UserInfo=>Future[Result]) = userInfoCache.infoForVaultId(vaultId) match {
+    case Some(userInfo)=>block(userInfo)
+    case None=>Future(NotFound(GenericErrorResponse("not_found","").asJson))
+  }
+
+  def initiate(vaultId:String,projectId:String) = IsAuthenticatedAsync { uid=> request=>
+    val expiry = config.getOptional[Int]("serverToken.shortLivedDuration").getOrElse(10)
+    val newToken = ServerTokenEntry.create(Some(projectId + "|" + vaultId), expiry, Some(uid))
+    serverTokenDAO.put(newToken, expiry)
+      .map(_=>Ok(GenericObjectResponse("ok","link",s"archivehunter:vaultdownload:${newToken.value}").asJson))
+      .recover({
+        case err:Throwable=>
+          logger.error(s"Could not save token with id ${newToken.value} for project ${projectId} to backend: ",err)
+          InternalServerError(GenericErrorResponse("db_error","Could not save token").asJson)
+      })
+  }
+
+  def getContent(userInfo:UserInfo, projectId:String) = {
+    val searchTerms = Array(SearchTerm.createSimpleTerm("GNM_PROJECT_ID", projectId))
+    val usefulFields = Array("MXFS_PATH","MXFS_FILENAME","DPSP_SIZE")
+    val sinkFact = Sink.seq[ArchiveEntryDownloadSynopsis]
+    val graph = GraphDSL.create(sinkFact) { implicit builder=> sink=>
+      import akka.stream.scaladsl.GraphDSL.Implicits._
+
+      val src = builder.add(new OMFastSearchSource(userInfo, searchTerms, usefulFields))
+      val converter = builder.add(new MakeDownloadSynopsis)
+      src ~> converter ~> sink
+      ClosedShape
+    }
+
+    RunnableGraph.fromGraph(graph).run()
+  }
+
+  def createRetrievalToken(uid:String, combinedId:String) = {
+    val expiry = config.getOptional[Int]("serverToken.longLivedDuration").getOrElse(3600)
+    val newToken = ServerTokenEntry.create(Some(combinedId), expiry, Some(uid))
+    serverTokenDAO.put(newToken, expiry).map(_=>newToken)
+  }
+
+  def getBulkDownload(tokenId:String) = Action.async {
+    serverTokenDAO.get(tokenId).flatMap({
+      case None=>
+        Future(NotFound(GenericErrorResponse("not_found","No such bulk download").asJson))
+      case Some(token)=>
+        token.associatedId match {
+          case None=>
+            logger.error(s"Token $tokenId is invalid, it does not contain a project ID")
+            Future(NotFound(GenericErrorResponse("not_found","Invalid token").asJson))
+          case Some(combinedId)=>
+            serverTokenDAO.remove(tokenId).flatMap(_=> {
+              val ids = combinedId.split("|")
+              val projectId = ids.head
+              val vaultId = ids(1)
+
+              withVaultAsync(vaultId) { userInfo =>
+                getContent(userInfo, projectId).map(synopses => {
+                  val meta = LightboxBulkEntry(projectId, "", token.createdForUser.getOrElse(""), ZonedDateTime.now(), 0, synopses.length, 0)
+                  BulkDownloadInitiateResponse("ok", meta, retrievalToken, synopses)
+                })
+              }
+            })
+        }
+    })
+  }
+}

--- a/app/controllers/BulkDownloadController.scala
+++ b/app/controllers/BulkDownloadController.scala
@@ -81,7 +81,7 @@ class BulkDownloadController @Inject() (cc:ControllerComponents, config:Configur
       import akka.stream.scaladsl.GraphDSL.Implicits._
 
       val src = builder.add(new OMFastSearchSource(userInfo, searchTerms, usefulFields))
-      val converter = builder.add(new MakeDownloadSynopsis)
+      val converter = builder.add(new MakeDownloadSynopsis(config.getOptional[Seq[String]]("bulkDownload.stripPrefixes")))
       src ~> converter ~> sink
       ClosedShape
     }

--- a/app/controllers/ObjectMatrixEntryMixin.scala
+++ b/app/controllers/ObjectMatrixEntryMixin.scala
@@ -21,7 +21,7 @@ trait ObjectMatrixEntryMixin {
     val optionalFields = Seq(
       //entry.attributes.flatMap(_.stringValues.get("MXFS_MODIFICATION_TIME")).map(s=>"ETag"->s),
       contentRangeHeader.map(hdr=>"Content-Range"->hdr),
-      entry.attributes.flatMap(_.stringValues.get("MXFS_FILENAME")).map(filename=>"Content-Disposition"->s"filename=$filename")
+      entry.attributes.flatMap(_.stringValues.get("MXFS_FILENAME")).map(filename=>"Content-Disposition"->s"filename=${java.net.URLEncoder.encode(filename, "utf-8")}")
     ).collect({case Some(field)=>field})
 
 

--- a/app/controllers/ObjectMatrixEntryMixin.scala
+++ b/app/controllers/ObjectMatrixEntryMixin.scala
@@ -1,11 +1,14 @@
 package controllers
 
-import helpers.RangeHeader
+import helpers.{MetadataHelper, RangeHeader}
 import models.ObjectMatrixEntry
 import org.slf4j.Logger
 
+import scala.util.Try
+
 trait ObjectMatrixEntryMixin {
   protected val logger:Logger
+
   /**
     * gathers appropriate headers for the given [[ObjectMatrixEntry]]
     * @param entry [[ObjectMatrixEntry]] instance
@@ -16,7 +19,7 @@ trait ObjectMatrixEntryMixin {
     val contentRangeHeader = ranges.headOption.map(range=>s"bytes ${range.headerString}${totalSize.map(s=>s"/$s").getOrElse("")}")
 
     val optionalFields = Seq(
-      entry.attributes.flatMap(_.stringValues.get("MXFS_MODIFICATION_TIME")).map(s=>"Etag"->s),
+      //entry.attributes.flatMap(_.stringValues.get("MXFS_MODIFICATION_TIME")).map(s=>"ETag"->s),
       contentRangeHeader.map(hdr=>"Content-Range"->hdr),
       entry.attributes.flatMap(_.stringValues.get("MXFS_FILENAME")).map(filename=>"Content-Disposition"->s"filename=$filename")
     ).collect({case Some(field)=>field})

--- a/app/controllers/ObjectMatrixEntryMixin.scala
+++ b/app/controllers/ObjectMatrixEntryMixin.scala
@@ -19,7 +19,6 @@ trait ObjectMatrixEntryMixin {
     val contentRangeHeader = ranges.headOption.map(range=>s"bytes ${range.headerString}${totalSize.map(s=>s"/$s").getOrElse("")}")
 
     val optionalFields = Seq(
-      //entry.attributes.flatMap(_.stringValues.get("MXFS_MODIFICATION_TIME")).map(s=>"ETag"->s),
       contentRangeHeader.map(hdr=>"Content-Range"->hdr),
       entry.attributes.flatMap(_.stringValues.get("MXFS_FILENAME")).map(filename=>"Content-Disposition"->s"filename=${java.net.URLEncoder.encode(filename, "utf-8")}")
     ).collect({case Some(field)=>field})

--- a/app/controllers/UiController.scala
+++ b/app/controllers/UiController.scala
@@ -2,11 +2,12 @@ package controllers
 
 import java.util.Properties
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import org.slf4j.LoggerFactory
 import play.api.Configuration
 import play.api.mvc.{AbstractController, ControllerComponents}
 
+@Singleton
 class UiController @Inject() (config:Configuration,cc:ControllerComponents) extends AbstractController(cc) {
   private val logger = LoggerFactory.getLogger(getClass)
 

--- a/app/models/ArchiveEntryDownloadSynopsis.scala
+++ b/app/models/ArchiveEntryDownloadSynopsis.scala
@@ -6,7 +6,3 @@ case class ArchiveEntryDownloadSynopsis(entryId:String, path:String, fileSize:Lo
 /*
 this model is lifted directly from ArchiveHunter, it is the data format that Download Manager expects to receive.
  */
-
-object ArchiveEntryDownloadSynopsis extends ((String, String, Long)=>ArchiveEntryDownloadSynopsis) {
-
-}

--- a/app/models/ArchiveEntryDownloadSynopsis.scala
+++ b/app/models/ArchiveEntryDownloadSynopsis.scala
@@ -1,0 +1,12 @@
+package models
+
+
+case class ArchiveEntryDownloadSynopsis(entryId:String, path:String, fileSize:Long)
+
+/*
+this model is lifted directly from ArchiveHunter, it is the data format that Download Manager expects to receive.
+ */
+
+object ArchiveEntryDownloadSynopsis extends ((String, String, Long)=>ArchiveEntryDownloadSynopsis) {
+
+}

--- a/app/models/LightboxBulkEntry.scala
+++ b/app/models/LightboxBulkEntry.scala
@@ -1,0 +1,17 @@
+package models
+
+import java.time.ZonedDateTime
+import java.util.UUID
+
+/*
+this model is lifted directly from ArchiveHunter, it is the data format that Download Manager expects to receive.
+ */
+
+case class LightboxBulkEntry (id:String, description:String, userEmail:String, addedAt: ZonedDateTime, errorCount:Int, availCount:Int, restoringCount:Int)
+
+object LightboxBulkEntry extends ((String,String,String,ZonedDateTime,Int,Int,Int)=>LightboxBulkEntry) {
+  def create(userEmail:String, description:String, addTime:Option[ZonedDateTime]=None) =
+    new LightboxBulkEntry(UUID.randomUUID().toString, description, userEmail, addTime.getOrElse(ZonedDateTime.now()),0,0,0)
+
+  def forLoose(userEmail:String, count:Int) = LightboxBulkEntry("loose","Loose items", userEmail, ZonedDateTime.now(),0,count,0)
+}

--- a/app/models/ServerTokenDAO.scala
+++ b/app/models/ServerTokenDAO.scala
@@ -15,4 +15,6 @@ trait ServerTokenDAO {
   def put(entry:ServerTokenEntry, expiresIn:Int):Future[Boolean]
 
   def get(tokenValue:String):Future[Option[ServerTokenEntry]]
+
+  def remove(tokenValue:String):Future[Boolean]
 }

--- a/app/models/ServerTokenDAO.scala
+++ b/app/models/ServerTokenDAO.scala
@@ -1,0 +1,18 @@
+package models
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import javax.inject.Inject
+import play.api.Configuration
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait ServerTokenDAO {
+  protected implicit val actorSystem:ActorSystem
+  protected implicit val mat:Materializer
+  protected implicit val ec:ExecutionContext = actorSystem.dispatcher
+
+  def put(entry:ServerTokenEntry, expiresIn:Int):Future[Boolean]
+
+  def get(tokenValue:String):Future[Option[ServerTokenEntry]]
+}

--- a/app/models/ServerTokenDAORedis.scala
+++ b/app/models/ServerTokenDAORedis.scala
@@ -1,0 +1,41 @@
+package models
+
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import javax.inject.Inject
+import play.api.Configuration
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.slf4j.LoggerFactory
+import scala.concurrent.Future
+
+class ServerTokenDAORedis @Inject() (config:Configuration) (override protected implicit val actorSystem:ActorSystem, override implicit val mat:Materializer) extends ServerTokenDAO {
+  private final val logger = LoggerFactory.getLogger(getClass)
+  lazy val redisClient = scredis.Client(
+    host = config.get[String]("redis.host"),
+    port = config.getOptional[Int]("redis.port").getOrElse(6376),
+    passwordOpt = config.getOptional[String]("redis.password")
+  )
+
+  override def get(tokenValue: String): Future[Option[ServerTokenEntry]] =
+    redisClient.get(s"vaultdoor:servertoken:$tokenValue")
+      .map(_.map(io.circe.parser.parse)).flatMap({
+        case None=>Future(None)
+        case Some(Left(parseError))=>
+          logger.error(s"Could not parse content for server token '$tokenValue' from redis: ${parseError.toString}, deleting it")
+          redisClient.del(s"vaultdoor:servertoken:$tokenValue").map(_=>None)
+        case Some(Right(json))=>
+          json.as[ServerTokenEntry] match {
+            case Left(marshalErr)=>
+              logger.error(s"Could not marshal content for server token '$tokenValue from redis: ${marshalErr.toString}, deleting it")
+              redisClient.del(s"vaultdoor:servertoken:$tokenValue").map(_=>None)
+            case Right(tok)=>
+              Future(Some(tok))
+          }
+      })
+
+
+  override def put(entry: ServerTokenEntry, expiresIn:Int): Future[Boolean] = {
+    redisClient.setEX(s"vaultdoor:servertoken:${entry.value}",entry.asJson.noSpaces, expiresIn).map(_=>true)
+  }
+}

--- a/app/models/ServerTokenDAORedis.scala
+++ b/app/models/ServerTokenDAORedis.scala
@@ -38,4 +38,6 @@ class ServerTokenDAORedis @Inject() (config:Configuration) (override protected i
   override def put(entry: ServerTokenEntry, expiresIn:Int): Future[Boolean] = {
     redisClient.setEX(s"vaultdoor:servertoken:${entry.value}",entry.asJson.noSpaces, expiresIn).map(_=>true)
   }
+
+  override def remove(tokenValue:String):Future[Boolean] = redisClient.del(s"vaultdoor:servertoken:$tokenValue").map(_=>true)
 }

--- a/app/models/ServerTokenDAORedis.scala
+++ b/app/models/ServerTokenDAORedis.scala
@@ -13,7 +13,7 @@ class ServerTokenDAORedis @Inject() (config:Configuration) (override protected i
   private final val logger = LoggerFactory.getLogger(getClass)
   lazy val redisClient = scredis.Client(
     host = config.get[String]("redis.host"),
-    port = config.getOptional[Int]("redis.port").getOrElse(6376),
+    port = config.getOptional[Int]("redis.port").getOrElse(6379),
     passwordOpt = config.getOptional[String]("redis.password")
   )
 

--- a/app/models/ServerTokenDAORedis.scala
+++ b/app/models/ServerTokenDAORedis.scala
@@ -2,13 +2,15 @@ package models
 
 import akka.actor.ActorSystem
 import akka.stream.Materializer
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import io.circe.generic.auto._
 import io.circe.syntax._
 import org.slf4j.LoggerFactory
+
 import scala.concurrent.Future
 
+@Singleton
 class ServerTokenDAORedis @Inject() (config:Configuration) (override protected implicit val actorSystem:ActorSystem, override implicit val mat:Materializer) extends ServerTokenDAO {
   private final val logger = LoggerFactory.getLogger(getClass)
   lazy val redisClient = scredis.Client(

--- a/app/models/ServerTokenDAORedis.scala
+++ b/app/models/ServerTokenDAORedis.scala
@@ -42,4 +42,9 @@ class ServerTokenDAORedis @Inject() (config:Configuration) (override protected i
   }
 
   override def remove(tokenValue:String):Future[Boolean] = redisClient.del(s"vaultdoor:servertoken:$tokenValue").map(_=>true)
+
+  override def finalize(): Unit = {
+    redisClient.quit()
+    super.finalize()
+  }
 }

--- a/app/models/ServerTokenEntry.scala
+++ b/app/models/ServerTokenEntry.scala
@@ -1,0 +1,64 @@
+package models
+
+import java.time.{Instant, ZonedDateTime}
+
+/*
+this class is taken from ArchiveHunter to implement one-time and multi-use tokens
+ */
+
+case class ServerTokenEntry (value:String, createdAt:ZonedDateTime, createdForUser:Option[String], expiry:Option[ZonedDateTime], uses:Int, expired:Boolean, associatedId:Option[String]) {
+  /**
+    * return an updated version of the token with the expired flag set if expiry time is passed. If expiry time is not passed same object
+    * is returned
+    * @return a ServerTokenEntry
+    */
+  def updateCheckExpired(maxUses:Option[Int]=None):ServerTokenEntry = {
+    val firstCheck = expiry match {
+      case Some(actualExpiry) =>
+        if (actualExpiry.isBefore(ZonedDateTime.now())) {
+          this.copy(expired = true)
+        } else {
+          this
+        }
+    }
+
+    if(firstCheck==this){
+      maxUses match {
+        case Some(maxUsesValue)=>
+          if(uses>=maxUsesValue){
+            this.copy(expired = true)
+          } else {
+            this
+          }
+        case None=>this
+      }
+    } else firstCheck
+  }
+}
+
+object ServerTokenEntry extends ((String, ZonedDateTime, Option[String], Option[ZonedDateTime], Int, Boolean,Option[String])=>ServerTokenEntry) {
+  def randomStringFromCharList(length: Int, chars: Seq[Char]): String = {
+    val sb = new StringBuilder
+    for (i <- 1 to length) {
+      val randomNum = util.Random.nextInt(chars.length)
+      sb.append(chars(randomNum))
+    }
+    sb.toString
+  }
+
+  def randomAlphaNumericString(length: Int): String = {
+    val chars = ('a' to 'z') ++ ('A' to 'Z') ++ ('0' to '9')
+    randomStringFromCharList(length, chars)
+  }
+
+  /**
+    * the standard way to create a token. Simply specify a duration or leave blank for 60s
+    * @param duration how long this token should be valid for
+    * @return a ServerTokenEntry (not saved to db)
+    */
+  def create(associatedId:Option[String]=None, duration:Int=60, forUser:Option[String]):ServerTokenEntry = {
+    val expiry:ZonedDateTime = ZonedDateTime.now().plusSeconds(duration.toLong)
+
+    ServerTokenEntry(randomAlphaNumericString(36),ZonedDateTime.now(),forUser, Some(expiry),0,false, associatedId)
+  }
+}

--- a/app/responses/BulkDownloadInitiateResponse.scala
+++ b/app/responses/BulkDownloadInitiateResponse.scala
@@ -1,0 +1,8 @@
+package responses
+
+import models.{ArchiveEntryDownloadSynopsis, LightboxBulkEntry}
+
+/*
+this response is lifted directly from ArchiveHunter, it is the data format that Download Manager expects to receive.
+ */
+case class BulkDownloadInitiateResponse(status:String, metadata:LightboxBulkEntry, retrievalToken:String, entries:Seq[ArchiveEntryDownloadSynopsis])

--- a/app/responses/DownloadManagerItemResponse.scala
+++ b/app/responses/DownloadManagerItemResponse.scala
@@ -1,0 +1,3 @@
+package responses
+
+case class DownloadManagerItemResponse(status:String, restoreStatus:String, downloadLink:String)

--- a/app/responses/GenericObjectResponse.scala
+++ b/app/responses/GenericObjectResponse.scala
@@ -1,0 +1,3 @@
+package responses
+
+case class GenericObjectResponse[T](status:String, itemClass:String, entry:T)

--- a/app/streamcomponents/MakeDownloadSynopsis.scala
+++ b/app/streamcomponents/MakeDownloadSynopsis.scala
@@ -5,11 +5,35 @@ import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, Gra
 import models.{ArchiveEntryDownloadSynopsis, ObjectMatrixEntry}
 import org.slf4j.LoggerFactory
 
-class MakeDownloadSynopsis extends GraphStage[FlowShape[ObjectMatrixEntry, ArchiveEntryDownloadSynopsis]] {
+class MakeDownloadSynopsis (maybeStripPrefixes:Option[Seq[String]]) extends GraphStage[FlowShape[ObjectMatrixEntry, ArchiveEntryDownloadSynopsis]] {
   private final val in:Inlet[ObjectMatrixEntry] = Inlet.create("MakeDownloadSynopsis.in")
   private final val out:Outlet[ArchiveEntryDownloadSynopsis] = Outlet.create("ArchiveEntryDownloadSynopsis")
 
   override def shape: FlowShape[ObjectMatrixEntry, ArchiveEntryDownloadSynopsis] = FlowShape.of(in,out)
+
+  /**
+    * recursively iterate the provided strip prefixes and remove the first one that matches
+    * @param filePath filepath determined from the appliance
+    * @return
+    */
+  def strippedPrefix(filePath:String) = maybeStripPrefixes match {
+    case None=>filePath
+    case Some(prefixesToRemove)=>
+      def stripNextPrefix(remainingList:Seq[String], onBaseString:String):String = {
+        if(remainingList.isEmpty){
+          onBaseString
+        } else {
+          val updatedString = if(onBaseString.startsWith(remainingList.head)){
+            return onBaseString.substring(remainingList.head.length)
+          } else {
+            onBaseString
+          }
+          stripNextPrefix(remainingList.tail, onBaseString)
+        }
+      }
+
+      stripNextPrefix(prefixesToRemove, filePath)
+  }
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
     private val logger:org.slf4j.Logger =  LoggerFactory.getLogger(getClass)
@@ -30,7 +54,7 @@ class MakeDownloadSynopsis extends GraphStage[FlowShape[ObjectMatrixEntry, Archi
       override def onPush(): Unit = {
         val elem = grab(in)
 
-        val maybeFilePath = elem.attributes.flatMap(_.stringValues.get("MXFS_FILENAME"))
+        val maybeFilePath = elem.attributes.flatMap(_.stringValues.get("MXFS_FILENAME").map(strippedPrefix))
         val maybeFileSize = determineSize(elem)
         val result = ArchiveEntryDownloadSynopsis(elem.oid, maybeFilePath.getOrElse(""), maybeFileSize)
         push(out, result)

--- a/app/streamcomponents/MakeDownloadSynopsis.scala
+++ b/app/streamcomponents/MakeDownloadSynopsis.scala
@@ -1,0 +1,40 @@
+package streamcomponents
+
+import akka.stream.{Attributes, FlowShape, Inlet, Outlet}
+import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic}
+import models.{ArchiveEntryDownloadSynopsis, ObjectMatrixEntry}
+import org.slf4j.LoggerFactory
+
+class MakeDownloadSynopsis extends GraphStage[FlowShape[ObjectMatrixEntry, ArchiveEntryDownloadSynopsis]] {
+  private final val in:Inlet[ObjectMatrixEntry] = Inlet.create("MakeDownloadSynopsis.in")
+  private final val out:Outlet[ArchiveEntryDownloadSynopsis] = Outlet.create("ArchiveEntryDownloadSynopsis")
+
+  override def shape: FlowShape[ObjectMatrixEntry, ArchiveEntryDownloadSynopsis] = FlowShape.of(in,out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+    private val logger:org.slf4j.Logger =  LoggerFactory.getLogger(getClass)
+
+    def determineSize(entry:ObjectMatrixEntry) = {
+      val maybeFileAttrSize = entry.fileAttribues.map(_.size)
+      val maybeMetaSize = entry.attributes.flatMap(_.longValues.get("DPSP_SIZE"))
+      val maybeMetaStringSize = entry.attributes.flatMap(_.stringValues.get("DPSP_SIZE").map(_.toLong))
+
+      maybeFileAttrSize.getOrElse(maybeMetaSize.getOrElse(maybeMetaStringSize.getOrElse(0L)))
+    }
+
+    setHandler(out, new AbstractOutHandler {
+      override def onPull(): Unit = pull(in)
+    })
+
+    setHandler(in, new AbstractInHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+
+        val maybeFilePath = elem.attributes.flatMap(_.stringValues.get("MXFS_FILENAME"))
+        val maybeFileSize = determineSize(elem)
+        val result = ArchiveEntryDownloadSynopsis(elem.oid, maybeFilePath.getOrElse(""), maybeFileSize)
+        push(out, result)
+      }
+    })
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ libraryDependencies ++= Seq(
   "com.sksamuel.elastic4s" %% "elastic4s-http-streams" % elastic4sVersion,
   "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test",
   "com.sksamuel.elastic4s" %% "elastic4s-embedded" % elastic4sVersion % "test",
+  "com.github.scredis" %% "scredis" % "2.3.3",
   "org.specs2" %% "specs2-core" % "4.5.1" % Test,
   "org.specs2" %% "specs2-mock" % "4.5.1" % Test,
   "org.mockito" % "mockito-core" % "2.28.2" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ unmanagedResourceDirectories in Test +=  { baseDirectory ( _ /"target/web/public
 
 unmanagedBase := baseDirectory.value / "lib"
 
-val akkaVersion = "2.5.22"
+val akkaVersion = "2.5.26"
 val circeVersion = "0.9.3"
 val slf4jVersion = "1.7.25"
 val elastic4sVersion = "6.5.1"
@@ -48,6 +48,8 @@ libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-mock" % "4.5.1" % Test,
   "org.mockito" % "mockito-core" % "2.28.2" % Test,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
+  "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+  "com.typesafe.akka" %% "akka-protobuf" % akkaVersion,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
 )
 

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -28,6 +28,8 @@
     <logger name="application" level="WARN" />
 
     <logger name="controllers.VaultController" level="INFO"/>
+    <logger name="controllers.BulkDownloadController" level="DEBUG"/>
+
     <logger name="helpers" level="INFO"/>
     <logger name="actors" level="INFO"/>
     <logger name="streamcomponents" level="INFO"/>

--- a/conf/routes
+++ b/conf/routes
@@ -28,6 +28,11 @@ GET     /api/vault/:vaultId/projectSummary/:projectId @controllers.FileListContr
 HEAD    /api/vault/:vaultId/:oid                    @controllers.VaultController.headTargetContent(vaultId, oid)
 GET     /api/vault/:vaultId/:oid                    @controllers.VaultController.streamTargetContent(vaultId, oid)
 
+# these endpoints mirror ArchiveHunter so that the protocol used by DownloadManager works
+GET     /api/bulk/new/:vaultId/:projectId           @controllers.BulkDownloadController.initiate(vaultId, projectId)
+GET     /api/bulk/:codeValue                        @controllers.BulkDownloadController.getBulkDownload(codeValue)
+GET     /api/bulk/:tokenValue/get/:fileId           @controllers.BulkDownloadController.bulkDownloadItem(tokenValue, fileId)
+GET     /api/bulk/:tokenValue/get/:fileId/data      @controllers.BulkDownloadController.bulkDownloadItemData(tokenValue, fileId)
 
 # Map static resources from the /public folder to the /assets URL path
 GET     /assets/*file               controllers.Assets.at(path="/public", file)

--- a/frontend/app/projectsearch/ProjectContentSummary.jsx
+++ b/frontend/app/projectsearch/ProjectContentSummary.jsx
@@ -116,8 +116,29 @@ class ProjectContentSummary extends React.Component {
 
     }
 
+    async requestDownloadLink() {
+        const url = "/api/bulk/new/" + this.props.vaultId + "/" + this.props.projectId;
+        const result = await fetch(url);
+        const bodyText = await result.text();
+
+        if(result.ok){
+            const content = JSON.parse(bodyText);
+            if(content.status==="ok" && content.itemClass==="link"){
+                window.location.href = content.entry;
+            } else {
+                console.log("Got malformed response ", content);
+                return this.setStatePromise({lastError: "malformed server response, check javascript logs for details"});
+            }
+        } else {
+            return this.setStatePromise({lastError: bodyText});
+        }
+    }
+
     initiateDownload(){
-        this.setState({lastError: "Not yet implemented"})
+        this.requestDownloadLink().catch(err=>{
+            console.error(err);
+            this.setState({lastError: "Clientside error, check javascript logs for details"});
+        })
     }
 
     render(){

--- a/frontend/app/projectsearch/ProjectContentSummary.jsx
+++ b/frontend/app/projectsearch/ProjectContentSummary.jsx
@@ -124,7 +124,7 @@ class ProjectContentSummary extends React.Component {
         if(result.ok){
             const content = JSON.parse(bodyText);
             if(content.status==="ok" && content.itemClass==="link"){
-                window.location.href = content.entry;
+                return this.setStatePromise({lastError: null}).then(()=>window.location.href = content.entry);
             } else {
                 console.log("Got malformed response ", content);
                 return this.setStatePromise({lastError: "malformed server response, check javascript logs for details"});

--- a/scripts/run-local-redis.sh
+++ b/scripts/run-local-redis.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -it -p 6379:6379 redis:5-alpine


### PR DESCRIPTION
Implements the server-side portion of Archive Hunter's media download protocol, so Download Manager is able to obtain content from vaultdoor.

Download manager must be updated from https://github.com/guardian/ArchiveHunterDownloadManager/tree/ag_vaultdoor in order to be able to connect.

I have also implemented a commandline client that works cross-platform (win, mac, linux) to read from this endpoint at https://github.com/guardian/autopull